### PR TITLE
Add store section detection on pages

### DIFF
--- a/src/app/code/Fera/Ai/view/frontend/layout/catalog_category_view.xml
+++ b/src/app/code/Fera/Ai/view/frontend/layout/catalog_category_view.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="fera.ai.footer">
+            <block class="Fera\Ai\Block\Footer"
+                   name="fera_ai.footer.product.list"
+                   template="Fera_Ai::footer/product/list.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/src/app/code/Fera/Ai/view/frontend/templates/footer.phtml
+++ b/src/app/code/Fera/Ai/view/frontend/templates/footer.phtml
@@ -17,6 +17,7 @@
 
         window.fera.push('setCart', <?= $block->getCartJson(); ?>);
     </script>
+    <?= $this->getChildHtml('fera_ai.footer.product.list'); ?>
     <?= $this->getChildHtml('fera_ai.footer.product.view'); ?>
     <?= $this->getChildHtml('fera_ai.footer.checkout.success'); ?>
     <script async type="application/javascript" src="<?= $block->getJsUrl(); ?>"></script>

--- a/src/app/code/Fera/Ai/view/frontend/templates/footer/product/list.phtml
+++ b/src/app/code/Fera/Ai/view/frontend/templates/footer/product/list.phtml
@@ -1,0 +1,4 @@
+<script>
+    window.fera = window.fera || [];
+    window.fera.push('setSection', 'product_list');
+</script>

--- a/src/app/code/Fera/Ai/view/frontend/templates/footer/product/view.phtml
+++ b/src/app/code/Fera/Ai/view/frontend/templates/footer/product/view.phtml
@@ -1,4 +1,5 @@
 <script>
     window.fera = window.fera || [];
     window.fera.push('setProduct', <?= $block->getProductJson(); ?>);
+    window.fera.push('setSection', 'product_view');
 </script>


### PR DESCRIPTION
Ora Link https://ora.pm/project/11168/kanban/task/3757298

## Why?
I am not sure if this is typical of all Magento 2 stores but I noticed there isn't enough information in the store URLs for them to be a reliable source for detecting store sections. Skills meant for the product page did not show because the sections were not detected correctly.


## What did you do?
Setting store section from the specific page ensures we are on the right section.

![Screen Shot 2020-09-23 at 9 53 05 AM](https://user-images.githubusercontent.com/11008869/94022469-1ef2e780-fd83-11ea-837d-a42e5cadda01.png)
![Screen Shot 2020-09-23 at 9 53 36 AM](https://user-images.githubusercontent.com/11008869/94022471-1f8b7e00-fd83-11ea-90b7-01c4185915b3.png)
